### PR TITLE
add a run_server class method to Device

### DIFF
--- a/src/boost/python/server.py
+++ b/src/boost/python/server.py
@@ -444,7 +444,7 @@ class Device(LatestDeviceImpl):
     def get_device_properties(self, ds_class = None):
         if ds_class is None:
             try:
-                # Call this method in a try/except in case this is called during 
+                # Call this method in a try/except in case this is called during
                 # the DS shutdown sequence
                 ds_class = self.get_device_class()
             except:
@@ -458,7 +458,7 @@ class Device(LatestDeviceImpl):
                 value = pu.get_property_values(prop_name, class_prop)
                 self._tango_properties[prop_name] = value
             for prop_name in self.device_property_list:
-                value = self.prop_util.get_property_values(prop_name, 
+                value = self.prop_util.get_property_values(prop_name,
                                                            self.device_property_list)
                 self._tango_properties[prop_name] = value
         except DevFailed as df:
@@ -480,6 +480,26 @@ class Device(LatestDeviceImpl):
         when necessary.
         """
         pass
+
+    @classmethod
+    def run_server(cls, args=None, **kwargs):
+        """Run the class as a device server.
+        It is based on the PyTango.server.run method.
+
+        The difference is that the device class
+        and server name are automatically given.
+
+        Args:
+            args (iterable): args as given in the PyTango.server.run method
+                             without the server name. If None, the sys.argv
+                             list is used
+            kwargs: the other keywords argument are as given
+                    in the PyTango.server.run method.
+        """
+        if args is None:
+            args = sys.argv[1:]
+        args = [cls.__name__] + list(args)
+        return run((cls,), args, **kwargs)
 
 
 class attribute(AttrData):


### PR DESCRIPTION
Hi Tiago,

Another small PR to add a `run_server` class method to `Device`. We have a lot of servers that actually consist of a single TANGO class, so it would be quite useful for us. It could also be nice for tutorials and examples.

Also, it gets the server name from the class instead of the file name. It is quite useful to break this rule to run the server from the cli and to comply with the standard names for python modules. Example:

`mydevice.py` defines the device class and the main execution:
```python
class MyDevice(Device):
    [...]

if __name__ == "__main__":
    MyDevice.run_server()
```
It is then possible to run the server using:
```batch
$ python -m mydevice my_instance_name 
```
Thanks