### PR TITLE
Device inheritance

### DIFF
--- a/src/boost/python/server.py
+++ b/src/boost/python/server.py
@@ -419,7 +419,10 @@ def inheritance_patch(attrs):
 
 def DeviceMeta(name, bases, attrs):
     """
-    The :py:data:`metaclass` callable for :class:`Device`.
+    The :py:data:`metaclass` callable for :class:`Device`.Every
+    sub-class of :class:`Device` must have associated this metaclass
+    to itself in order to work properly (boost-python internal
+    limitation).
 
     Example (python 2.x)::
 


### PR DESCRIPTION
Hi Tiago,

A last PR to discuss device inheritance. I've been using this code in production for quite some time and it's been working fine so far. Usage:

```python
class Parent(Device):
    __metaclass__ = DeviceMeta

    prop = device_property(dtype=str)

    attr = attribute(dtype=int)
    
    @command
    def cmd(self):
        pass

class Child(Parent):
    __metaclass__ = DeviceMeta

    # Child will have a 'prop' device property
    
    # Override 'attr'
    attr = attribute(dtype=float)
  
    # Remove 'cmd' from the command list
    cmd = None
```
However, it might need some refactoring:
- `is_tango_object` could have a cleaner implementation if `command` was a type.
- `inheritance_patch` prevents  `__patch_read_method`  to patch the read method multiple times, but it's a dirty workaround.

Thanks